### PR TITLE
Update type annotation syntax for dict.

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 from fastapi import FastAPI
 
 app = FastAPI()
 
 
 @app.get("/")
-def hello_world() -> Dict:
+def hello_world() -> dict:
     return {"message": "Hello World"}


### PR DESCRIPTION
Hi,

This updates the type annotation for Python 3.9:

```python
x: dict[str, float] = {"field": 2.0}  # Python 3.9+
```